### PR TITLE
XEP-0280+XEP-0333: Message Carbons and Chat Markers

### DIFF
--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -64,6 +64,7 @@ static const Feature self_advertised_features[] =
   { FEATURE_FIXED, NS_VERSION },
   { FEATURE_FIXED, NS_LAST },
   { FEATURE_FIXED, NS_RECEIPTS },
+  { FEATURE_FIXED, NS_CHAT_MARKERS },
 
 #ifdef ENABLE_FILE_TRANSFER
   { FEATURE_OPTIONAL, NS_FILE_TRANSFER },

--- a/src/connection.c
+++ b/src/connection.c
@@ -2905,6 +2905,25 @@ conn_wlm_jid_lookup_async (TpHandleRepoIface *repo,
   g_free (normal_id);
 }
 
+static void
+carbons_cb (GObject *source_object,
+    GAsyncResult *res,
+    gpointer user_data)
+{
+  GError *error = NULL;
+  WockyPorter *porter = WOCKY_PORTER (source_object);
+  WockyStanza *reply = wocky_porter_send_iq_finish (porter, res, &error);
+
+  if (reply == NULL ||
+      wocky_stanza_extract_errors (reply, NULL, &error, NULL, NULL))
+    {
+      DEBUG ("Failed to set carbons: %s", error->message);
+      g_error_free (error);
+    }
+
+  tp_clear_object (&reply);
+}
+
 static gchar *
 conn_wlm_jid_lookup_finish (TpHandleRepoIface *repo,
     GAsyncResult *result,
@@ -3001,6 +3020,8 @@ connection_disco_cb (GabbleDisco *disco,
                 conn->features |= GABBLE_CONNECTION_FEATURES_GOOGLE_SETTING;
               else if (0 == strcmp (var, NS_WLM_JID_LOOKUP))
                 conn->features |= GABBLE_CONNECTION_FEATURES_WLM_JID_LOOKUP;
+              else if (0 == strcmp (var, NS_CARBONS))
+                conn->features |= GABBLE_CONNECTION_FEATURES_CARBONS;
             }
         }
 
@@ -3016,6 +3037,27 @@ connection_disco_cb (GabbleDisco *disco,
           (TpDynamicHandleRepo *) contact_repo,
           conn_wlm_jid_lookup_async,
           conn_wlm_jid_lookup_finish);
+    }
+
+  if (conn->features & GABBLE_CONNECTION_FEATURES_CARBONS)
+    {
+      WockyStanza *query;
+      WockyPorter *porter;
+      gchar *full_jid;
+
+      full_jid = gabble_connection_get_full_jid (conn);
+      porter = wocky_session_get_porter (conn->session);
+      query = wocky_stanza_build (WOCKY_STANZA_TYPE_IQ,
+                                  WOCKY_STANZA_SUB_TYPE_SET, full_jid, NULL,
+                                  '(', "enable",
+                                    ':', NS_CARBONS,
+                                  ')',
+                                  NULL);
+      wocky_porter_send_iq_async (porter, query, NULL,
+                                  carbons_cb, conn);
+
+      g_object_unref (query);
+      g_free(full_jid);
     }
 
   conn_presence_set_initial_presence_async (conn,

--- a/src/connection.c
+++ b/src/connection.c
@@ -170,6 +170,7 @@ enum
     PROP_EXTRA_CERTIFICATE_IDENTITIES,
     PROP_POWER_SAVING,
     PROP_DOWNLOAD_AT_CONNECTION,
+    PROP_MESSAGE_CARBONS,
 
     LAST_PROPERTY
 };
@@ -221,6 +222,8 @@ struct _GabbleConnectionPrivate
   GStrv extra_certificate_identities;
 
   gboolean power_saving;
+
+  gboolean message_carbons;
 
   /* authentication properties */
   gchar *stream_server;
@@ -671,6 +674,10 @@ gabble_connection_get_property (GObject    *object,
         break;
       }
 
+    case PROP_MESSAGE_CARBONS:
+      g_value_set_boolean (value, priv->message_carbons);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
       break;
@@ -816,6 +823,10 @@ gabble_connection_set_property (GObject      *object,
       if (self->roster != NULL)
         g_object_set (self->roster, "download-at-connection",
             g_value_get_boolean (value), NULL);
+      break;
+
+    case PROP_MESSAGE_CARBONS:
+      priv->message_carbons = g_value_get_boolean (value);
       break;
 
     default:
@@ -1220,6 +1231,14 @@ gabble_connection_class_init (GabbleConnectionClass *gabble_connection_class)
       g_param_spec_boolean (
           "power-saving", "Power saving active?",
           "Queue remote presence updates server-side for less network chatter",
+          FALSE,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (
+      object_class, PROP_MESSAGE_CARBONS,
+      g_param_spec_boolean (
+          "message-carbons", "Message carbons enabled?",
+          "Client will receive other active resources messages",
           FALSE,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
@@ -3039,7 +3058,8 @@ connection_disco_cb (GabbleDisco *disco,
           conn_wlm_jid_lookup_finish);
     }
 
-  if (conn->features & GABBLE_CONNECTION_FEATURES_CARBONS)
+  if ((conn->features & GABBLE_CONNECTION_FEATURES_CARBONS)
+        && (conn->priv->message_carbons))
     {
       WockyStanza *query;
       WockyPorter *porter;

--- a/src/connection.c
+++ b/src/connection.c
@@ -172,6 +172,8 @@ enum
     PROP_DOWNLOAD_AT_CONNECTION,
     PROP_MESSAGE_CARBONS,
     PROP_SEND_CHAT_MARKERS,
+    PROP_FORCE_CHAT_MARKERS,
+    PROP_FORCE_RECEIPTS,
 
     LAST_PROPERTY
 };
@@ -227,6 +229,8 @@ struct _GabbleConnectionPrivate
   gboolean message_carbons;
 
   gboolean send_chat_markers;
+  gboolean force_chat_markers;
+  gboolean force_receipts;
 
   /* authentication properties */
   gchar *stream_server;
@@ -685,6 +689,14 @@ gabble_connection_get_property (GObject    *object,
       g_value_set_boolean (value, priv->send_chat_markers);
       break;
 
+    case PROP_FORCE_CHAT_MARKERS:
+      g_value_set_boolean (value, priv->force_chat_markers);
+      break;
+
+    case PROP_FORCE_RECEIPTS:
+      g_value_set_boolean (value, priv->force_receipts);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
       break;
@@ -838,6 +850,14 @@ gabble_connection_set_property (GObject      *object,
 
     case PROP_SEND_CHAT_MARKERS:
       priv->send_chat_markers = g_value_get_boolean (value);
+      break;
+
+    case PROP_FORCE_CHAT_MARKERS:
+      priv->force_chat_markers = g_value_get_boolean (value);
+      break;
+
+    case PROP_FORCE_RECEIPTS:
+      priv->force_receipts = g_value_get_boolean (value);
       break;
 
     default:
@@ -1258,6 +1278,22 @@ gabble_connection_class_init (GabbleConnectionClass *gabble_connection_class)
       g_param_spec_boolean (
           "send-chat-markers", "Send message read markers?",
           "Client will send read markers to sender",
+          FALSE,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (
+      object_class, PROP_FORCE_CHAT_MARKERS,
+      g_param_spec_boolean (
+          "force-chat-markers", "Always send message markers?",
+          "Client will send read markers and requests regardless of support",
+          FALSE,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (
+      object_class, PROP_FORCE_RECEIPTS,
+      g_param_spec_boolean (
+          "force-receipts", "Always send message receipts?",
+          "Client will send receipts and requests regardless of support",
           FALSE,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -3077,7 +3077,7 @@ connection_disco_cb (GabbleDisco *disco,
                                   carbons_cb, conn);
 
       g_object_unref (query);
-      g_free(full_jid);
+      g_free (full_jid);
     }
 
   conn_presence_set_initial_presence_async (conn,

--- a/src/connection.c
+++ b/src/connection.c
@@ -171,6 +171,7 @@ enum
     PROP_POWER_SAVING,
     PROP_DOWNLOAD_AT_CONNECTION,
     PROP_MESSAGE_CARBONS,
+    PROP_SEND_CHAT_MARKERS,
 
     LAST_PROPERTY
 };
@@ -224,6 +225,8 @@ struct _GabbleConnectionPrivate
   gboolean power_saving;
 
   gboolean message_carbons;
+
+  gboolean send_chat_markers;
 
   /* authentication properties */
   gchar *stream_server;
@@ -678,6 +681,10 @@ gabble_connection_get_property (GObject    *object,
       g_value_set_boolean (value, priv->message_carbons);
       break;
 
+    case PROP_SEND_CHAT_MARKERS:
+      g_value_set_boolean (value, priv->send_chat_markers);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
       break;
@@ -827,6 +834,10 @@ gabble_connection_set_property (GObject      *object,
 
     case PROP_MESSAGE_CARBONS:
       priv->message_carbons = g_value_get_boolean (value);
+      break;
+
+    case PROP_SEND_CHAT_MARKERS:
+      priv->send_chat_markers = g_value_get_boolean (value);
       break;
 
     default:
@@ -1239,6 +1250,14 @@ gabble_connection_class_init (GabbleConnectionClass *gabble_connection_class)
       g_param_spec_boolean (
           "message-carbons", "Message carbons enabled?",
           "Client will receive other active resources messages",
+          FALSE,
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (
+      object_class, PROP_SEND_CHAT_MARKERS,
+      g_param_spec_boolean (
+          "send-chat-markers", "Send message read markers?",
+          "Client will send read markers to sender",
           FALSE,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -138,6 +138,7 @@ typedef enum
   GABBLE_CONNECTION_FEATURES_GOOGLE_QUEUE = 1 << 8,
   GABBLE_CONNECTION_FEATURES_GOOGLE_SETTING = 1 << 9,
   GABBLE_CONNECTION_FEATURES_WLM_JID_LOOKUP = 1 << 10,
+  GABBLE_CONNECTION_FEATURES_CARBONS = 1 << 11,
 } GabbleConnectionFeatures;
 
 typedef struct _GabbleConnectionPrivate GabbleConnectionPrivate;

--- a/src/im-channel.c
+++ b/src/im-channel.c
@@ -472,6 +472,42 @@ maybe_send_delivery_report (
 }
 
 /*
+ * _gabble_im_channel_sent:
+ * @chan: a channel
+ * @type: the message type
+ * @to: the full JID we sent the message to
+ * @timestamp: the time at which the message was sent
+ * @id: the id='' attribute from the <message/> stanza, if any
+ * @text: the plaintext body of the message
+ *
+ * Shoves an outgoing message into @chan.
+ */
+void
+_gabble_im_channel_sent (GabbleIMChannel *chan,
+                         TpChannelTextMessageType type,
+                         time_t timestamp,
+                         const gchar *id,
+                         const char *text)
+{
+  TpBaseChannel *base_chan;
+  TpBaseConnection *base_conn;
+  TpMessage *msg;
+
+  g_assert (GABBLE_IS_IM_CHANNEL (chan));
+  base_chan = (TpBaseChannel *) chan;
+  base_conn = tp_base_channel_get_connection (base_chan);
+
+  msg = build_message (chan, type, timestamp, text);
+  tp_cm_message_set_sender (msg, tp_base_connection_get_self_handle (base_conn));
+  tp_message_set_int64 (msg, 0, "message-received", time (NULL));
+
+  if (id != NULL)
+    tp_message_set_string (msg, 0, "message-token", id);
+
+  tp_message_mixin_take_received (G_OBJECT (chan), msg);
+}
+
+/*
  * _gabble_im_channel_receive:
  * @chan: a channel
  * @message: the <message> stanza, from which all the following arguments were

--- a/src/im-channel.c
+++ b/src/im-channel.c
@@ -73,6 +73,7 @@ struct _GabbleIMChannelPrivate
   gchar *peer_jid;
   gboolean send_nick;
   ChatStateSupport chat_states_supported;
+  GHashTable *pending_messages;
 
   gboolean dispose_has_run;
 };
@@ -106,6 +107,49 @@ gabble_im_channel_init (GabbleIMChannel *self)
       GABBLE_TYPE_IM_CHANNEL, GabbleIMChannelPrivate);
 
   self->priv = priv;
+}
+
+static void _gabble_im_channel_pending_messages_removed_cb ( TpSvcChannelInterfaceMessages *iface,
+                                GArray *arg_Message_IDs,
+                                gpointer user_data)
+{
+  GabbleIMChannel *self = GABBLE_IM_CHANNEL (user_data);
+  GabbleIMChannelPrivate *priv = self->priv;
+
+  int size = g_array_get_element_size (arg_Message_IDs);
+
+  for (int i=0; i<size; i++)
+    {
+      guint id = g_array_index (arg_Message_IDs, guint, i);
+      gchar* token;
+
+      DEBUG ("lookup messageid: %u", id);
+      token = g_hash_table_lookup (priv->pending_messages, GINT_TO_POINTER (id));
+
+      if (token)
+        {
+          TpBaseChannel *base = TP_BASE_CHANNEL (self);
+          TpBaseConnection *base_conn = tp_base_channel_get_connection (base);
+          GabbleConnection *conn = GABBLE_CONNECTION (base_conn);
+
+          WockyStanza *report = wocky_stanza_build (
+            WOCKY_STANZA_TYPE_MESSAGE, WOCKY_STANZA_SUB_TYPE_NONE,
+            NULL, priv->peer_jid,
+            '(', "displayed", ':', NS_CHAT_MARKERS,
+              '@', "id", token,
+            ')', NULL);
+
+          _gabble_connection_send (conn, report, NULL);
+
+          DEBUG ("messageid: %u = %s", id, token);
+
+          g_hash_table_remove (priv->pending_messages, GINT_TO_POINTER (id));
+        }
+      else
+          DEBUG ("messageid: %u not found", id);
+    }
+
+  return;
 }
 
 static void
@@ -157,6 +201,10 @@ gabble_im_channel_constructed (GObject *obj)
   priv->chat_states_supported = CHAT_STATES_UNKNOWN;
   tp_message_mixin_implement_send_chat_state (obj,
       _gabble_im_channel_send_chat_state);
+
+  priv->pending_messages = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL, g_free);
+
+  g_signal_connect (obj, "pending-messages-removed", (GCallback)_gabble_im_channel_pending_messages_removed_cb, self);
 }
 
 static void gabble_im_channel_dispose (GObject *object);
@@ -311,6 +359,8 @@ gabble_im_channel_finalize (GObject *object)
 
   tp_message_mixin_finalize (object);
 
+  g_hash_table_unref (priv->pending_messages);
+
   G_OBJECT_CLASS (gabble_im_channel_parent_class)->finalize (object);
 }
 
@@ -378,16 +428,20 @@ _gabble_im_channel_send_message (GObject *object,
 
   if (stanza != NULL)
     {
+      TpMessageSendingFlags supportedflags = 0;
       if ((flags & TP_MESSAGE_SENDING_FLAG_REPORT_DELIVERY) &&
           receipts_conceivably_supported (self))
         {
           wocky_node_add_child_ns (wocky_stanza_get_top_node (stanza),
               "request", NS_RECEIPTS);
-          flags = TP_MESSAGE_SENDING_FLAG_REPORT_DELIVERY;
+          supportedflags |= TP_MESSAGE_SENDING_FLAG_REPORT_DELIVERY;
         }
-      else
+      if ((flags & TP_MESSAGE_SENDING_FLAG_REPORT_READ) &&
+          receipts_conceivably_supported (self))
         {
-          flags = 0;
+          wocky_node_add_child_ns (wocky_stanza_get_top_node (stanza),
+              "markable", NS_CHAT_MARKERS);
+          supportedflags |= TP_MESSAGE_SENDING_FLAG_REPORT_READ;
         }
 
       porter = gabble_connection_dup_porter (gabble_conn);
@@ -395,7 +449,7 @@ _gabble_im_channel_send_message (GObject *object,
       context->channel = g_object_ref (base);
       context->message = g_object_ref (message);
       context->token = id;
-      context->flags = flags;
+      context->flags = supportedflags;
       wocky_porter_send_async (porter, stanza, NULL,
           _gabble_im_channel_message_sent_cb, context);
       g_object_unref (porter);
@@ -538,6 +592,7 @@ _gabble_im_channel_receive (GabbleIMChannel *chan,
   TpBaseChannel *base_chan;
   TpHandle peer;
   TpMessage *msg;
+  guint nid;
 
   g_assert (GABBLE_IS_IM_CHANNEL (chan));
   priv = chan->priv;
@@ -563,7 +618,13 @@ _gabble_im_channel_receive (GabbleIMChannel *chan,
   if (id != NULL)
     tp_message_set_string (msg, 0, "message-token", id);
 
-  tp_message_mixin_take_received (G_OBJECT (chan), msg);
+  nid = tp_message_mixin_take_received (G_OBJECT (chan), msg);
+
+  if (id)
+    {
+      DEBUG ("insert %d = %s", nid, id);
+      g_hash_table_insert (priv->pending_messages, GINT_TO_POINTER (nid), g_strdup (id));
+    }
   maybe_send_delivery_report (chan, message, from, id);
 }
 
@@ -662,11 +723,12 @@ _gabble_im_channel_state_receive (GabbleIMChannel *chan,
 void
 gabble_im_channel_receive_receipt (
     GabbleIMChannel *self,
-    const gchar *receipt_id)
+    const gchar *receipt_id,
+    TpDeliveryStatus status)
 {
   _gabble_im_channel_report_delivery (self,
         TP_CHANNEL_TEXT_MESSAGE_TYPE_NORMAL, 0, receipt_id, NULL,
-        GABBLE_TEXT_CHANNEL_SEND_NO_ERROR, TP_DELIVERY_STATUS_DELIVERED);
+        GABBLE_TEXT_CHANNEL_SEND_NO_ERROR, status);
 }
 
 static void

--- a/src/im-channel.c
+++ b/src/im-channel.c
@@ -74,6 +74,7 @@ struct _GabbleIMChannelPrivate
   gboolean send_nick;
   ChatStateSupport chat_states_supported;
   GHashTable *pending_messages;
+  gboolean send_chat_markers;
 
   gboolean dispose_has_run;
 };
@@ -204,7 +205,10 @@ gabble_im_channel_constructed (GObject *obj)
 
   priv->pending_messages = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL, g_free);
 
-  g_signal_connect (obj, "pending-messages-removed", (GCallback)_gabble_im_channel_pending_messages_removed_cb, self);
+  g_object_get (conn, "send-chat-markers", &priv->send_chat_markers, NULL);
+
+  if (priv->send_chat_markers)
+    g_signal_connect (obj, "pending-messages-removed", (GCallback)_gabble_im_channel_pending_messages_removed_cb, self);
 }
 
 static void gabble_im_channel_dispose (GObject *object);
@@ -620,7 +624,7 @@ _gabble_im_channel_receive (GabbleIMChannel *chan,
 
   nid = tp_message_mixin_take_received (G_OBJECT (chan), msg);
 
-  if (id)
+  if ((id) && (priv->send_chat_markers))
     {
       DEBUG ("insert %d = %s", nid, id);
       g_hash_table_insert (priv->pending_messages, GINT_TO_POINTER (nid), g_strdup (id));

--- a/src/im-channel.c
+++ b/src/im-channel.c
@@ -136,7 +136,7 @@ static void _gabble_im_channel_pending_messages_removed_cb ( TpSvcChannelInterfa
           GabbleConnection *conn = GABBLE_CONNECTION (base_conn);
 
           WockyStanza *report = wocky_stanza_build (
-            WOCKY_STANZA_TYPE_MESSAGE, WOCKY_STANZA_SUB_TYPE_NONE,
+            WOCKY_STANZA_TYPE_MESSAGE, WOCKY_STANZA_SUB_TYPE_CHAT,
             NULL, priv->peer_jid,
             '(', "displayed", ':', NS_CHAT_MARKERS,
               '@', "id", token,

--- a/src/im-channel.h
+++ b/src/im-channel.h
@@ -63,6 +63,11 @@ GType gabble_im_channel_get_type (void);
   (G_TYPE_INSTANCE_GET_CLASS ((obj), GABBLE_TYPE_IM_CHANNEL, \
                               GabbleIMChannelClass))
 
+void _gabble_im_channel_sent (GabbleIMChannel *chan,
+    TpChannelTextMessageType type,
+    time_t timestamp,
+    const char *id,
+    const char *text);
 void _gabble_im_channel_receive (GabbleIMChannel *chan,
     WockyStanza *message,
     TpChannelTextMessageType type,

--- a/src/im-channel.h
+++ b/src/im-channel.h
@@ -80,7 +80,8 @@ void _gabble_im_channel_state_receive (GabbleIMChannel *chan,
     TpChannelChatState state);
 void gabble_im_channel_receive_receipt (
     GabbleIMChannel *self,
-    const gchar *receipt_id);
+    const gchar *receipt_id,
+    TpDeliveryStatus status);
 
 void _gabble_im_channel_report_delivery (
     GabbleIMChannel *self,

--- a/src/im-factory.c
+++ b/src/im-factory.c
@@ -230,10 +230,11 @@ im_factory_message_cb (
 
   /* We don't want to open up a channel for the sole purpose of reporting a
    * send error, nor if this is just a chat state notification.
+   * But we want observers to log receipts, so we do it for delivery reports.
    */
   create_if_missing =
-      (send_error == GABBLE_TEXT_CHANNEL_SEND_NO_ERROR) &&
-      (body != NULL);
+      ((send_error == GABBLE_TEXT_CHANNEL_SEND_NO_ERROR) &&
+      (body != NULL)) || (delivery_status != TP_DELIVERY_STATUS_UNKNOWN);
   chan = get_channel_for_incoming_message (fac, chan_jid, create_if_missing);
   if (chan == NULL)
     {

--- a/src/message-util.c
+++ b/src/message-util.c
@@ -518,7 +518,7 @@ gabble_message_util_parse_incoming_message (WockyStanza *message,
   *state = _tp_chat_state_from_message (message_node);
 
   /* Parse chat markers */
-  chat_marker = wocky_node_get_child_ns (wocky_stanza_get_top_node (message),
+  chat_marker = wocky_node_get_child_ns (message_node,
       "displayed", NS_CHAT_MARKERS);
 
   if (chat_marker)
@@ -536,7 +536,7 @@ gabble_message_util_parse_incoming_message (WockyStanza *message,
         }
     }
 
-  chat_marker = wocky_node_get_child_ns (wocky_stanza_get_top_node (message),
+  chat_marker = wocky_node_get_child_ns (message_node,
       "received", NS_CHAT_MARKERS);
 
   if (chat_marker)

--- a/src/message-util.h
+++ b/src/message-util.h
@@ -49,7 +49,7 @@ gboolean gabble_message_util_parse_incoming_message (WockyStanza *message,
     const gchar **from, const gchar **to, time_t *stamp,
     TpChannelTextMessageType *msgtype, const gchar **id,
     const gchar **body_ret, gint *state, TpChannelTextSendError *send_error,
-    TpDeliveryStatus *delivery_status, gboolean *sent);
+    TpDeliveryStatus *delivery_status, const gchar **delivery_token, gboolean *sent);
 
 TpChannelTextSendError
 gabble_tp_send_error_from_wocky_xmpp_error (WockyXmppError err);

--- a/src/message-util.h
+++ b/src/message-util.h
@@ -46,9 +46,10 @@ gboolean gabble_message_util_send_chat_state (GObject *obj,
 #define GABBLE_TEXT_CHANNEL_SEND_NO_ERROR ((TpChannelTextSendError)-1)
 
 gboolean gabble_message_util_parse_incoming_message (WockyStanza *message,
-    const gchar **from, time_t *stamp, TpChannelTextMessageType *msgtype,
-    const gchar **id, const gchar **body_ret, gint *state,
-    TpChannelTextSendError *send_error, TpDeliveryStatus *delivery_status);
+    const gchar **from, const gchar **to, time_t *stamp,
+    TpChannelTextMessageType *msgtype, const gchar **id,
+    const gchar **body_ret, gint *state, TpChannelTextSendError *send_error,
+    TpDeliveryStatus *delivery_status, gboolean *sent);
 
 TpChannelTextSendError
 gabble_tp_send_error_from_wocky_xmpp_error (WockyXmppError err);

--- a/src/muc-factory.c
+++ b/src/muc-factory.c
@@ -774,15 +774,17 @@ muc_factory_message_cb (
   GabbleMucFactory *fac = GABBLE_MUC_FACTORY (user_data);
   GabbleMucFactoryPrivate *priv = fac->priv;
 
-  const gchar *from, *body, *id;
+  const gchar *from, *to, *body, *id;
   time_t stamp;
   TpChannelTextMessageType msgtype;
   gint state;
   TpChannelTextSendError send_error;
   TpDeliveryStatus delivery_status;
+  gboolean sent;
 
-  if (!gabble_message_util_parse_incoming_message (message, &from, &stamp,
-        &msgtype, &id, &body, &state, &send_error, &delivery_status))
+  /* FIXME: handle sent? */
+  if (!gabble_message_util_parse_incoming_message (message, &from, &to, &stamp,
+        &msgtype, &id, &body, &state, &send_error, &delivery_status, &sent))
     return TRUE;
 
   if (conn_olpc_process_activity_properties_message (priv->conn, message,

--- a/src/muc-factory.c
+++ b/src/muc-factory.c
@@ -774,7 +774,7 @@ muc_factory_message_cb (
   GabbleMucFactory *fac = GABBLE_MUC_FACTORY (user_data);
   GabbleMucFactoryPrivate *priv = fac->priv;
 
-  const gchar *from, *to, *body, *id;
+  const gchar *from, *to, *body, *id, *delivery_token;
   time_t stamp;
   TpChannelTextMessageType msgtype;
   gint state;
@@ -784,7 +784,7 @@ muc_factory_message_cb (
 
   /* FIXME: handle sent? */
   if (!gabble_message_util_parse_incoming_message (message, &from, &to, &stamp,
-        &msgtype, &id, &body, &state, &send_error, &delivery_status, &sent))
+        &msgtype, &id, &body, &state, &send_error, &delivery_status, &delivery_token, &sent))
     return TRUE;
 
   if (conn_olpc_process_activity_properties_message (priv->conn, message,

--- a/src/namespaces.h
+++ b/src/namespaces.h
@@ -140,4 +140,7 @@
  * See http://msdn.microsoft.com/en-us/library/live/hh550849.aspx */
 #define NS_WLM_JID_LOOKUP "http://messenger.live.com/xmpp/jidlookup"
 
+#define NS_CARBONS "urn:xmpp:carbons:2"
+#define NS_FORWARD "urn:xmpp:forward:0"
+
 #endif /* __GABBLE_NAMESPACES__H__ */

--- a/src/namespaces.h
+++ b/src/namespaces.h
@@ -26,6 +26,7 @@
 #define NS_AMP                  "http://jabber.org/protocol/amp"
 #define NS_BYTESTREAMS          "http://jabber.org/protocol/bytestreams"
 #define NS_CHAT_STATES          "http://jabber.org/protocol/chatstates"
+#define NS_CHAT_MARKERS         "urn:xmpp:chat-markers:0"
 #define NS_DISCO_INFO           "http://jabber.org/protocol/disco#info"
 #define NS_DISCO_ITEMS          "http://jabber.org/protocol/disco#items"
 #define NS_FEATURENEG           "http://jabber.org/protocol/feature-neg"

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -184,6 +184,10 @@ static TpCMParamSpec jabber_params[] = {
   { "account-path-suffix", "s", G_TYPE_STRING,
     0, NULL, 0 /* unused */, NULL, NULL },
 
+  { "message-carbons", DBUS_TYPE_BOOLEAN_AS_STRING, G_TYPE_BOOLEAN,
+    TP_CONN_MGR_PARAM_FLAG_HAS_DEFAULT, GINT_TO_POINTER(FALSE),
+    0 /* unused */, NULL, NULL },
+
   { NULL, NULL, 0, 0, NULL, 0 }
 };
 
@@ -264,6 +268,7 @@ struct ParamMapping {
        "decloak-automatically"),
   SAME ("fallback-servers"),
   SAME ("extra-certificate-identities"),
+  SAME ("message-carbons"),
   SAME (NULL)
 };
 #undef SAME

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -188,6 +188,10 @@ static TpCMParamSpec jabber_params[] = {
     TP_CONN_MGR_PARAM_FLAG_HAS_DEFAULT, GINT_TO_POINTER(FALSE),
     0 /* unused */, NULL, NULL },
 
+  { "send-chat-markers", DBUS_TYPE_BOOLEAN_AS_STRING, G_TYPE_BOOLEAN,
+    TP_CONN_MGR_PARAM_FLAG_HAS_DEFAULT, GINT_TO_POINTER(FALSE),
+    0 /* unused */, NULL, NULL },
+
   { NULL, NULL, 0, 0, NULL, 0 }
 };
 
@@ -269,6 +273,7 @@ struct ParamMapping {
   SAME ("fallback-servers"),
   SAME ("extra-certificate-identities"),
   SAME ("message-carbons"),
+  SAME ("send-chat-markers"),
   SAME (NULL)
 };
 #undef SAME

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -192,6 +192,14 @@ static TpCMParamSpec jabber_params[] = {
     TP_CONN_MGR_PARAM_FLAG_HAS_DEFAULT, GINT_TO_POINTER(FALSE),
     0 /* unused */, NULL, NULL },
 
+  { "force-chat-markers", DBUS_TYPE_BOOLEAN_AS_STRING, G_TYPE_BOOLEAN,
+    TP_CONN_MGR_PARAM_FLAG_HAS_DEFAULT, GINT_TO_POINTER(FALSE),
+    0 /* unused */, NULL, NULL },
+
+  { "force-receipts", DBUS_TYPE_BOOLEAN_AS_STRING, G_TYPE_BOOLEAN,
+    TP_CONN_MGR_PARAM_FLAG_HAS_DEFAULT, GINT_TO_POINTER(FALSE),
+    0 /* unused */, NULL, NULL },
+
   { NULL, NULL, 0, 0, NULL, 0 }
 };
 
@@ -274,6 +282,8 @@ struct ParamMapping {
   SAME ("extra-certificate-identities"),
   SAME ("message-carbons"),
   SAME ("send-chat-markers"),
+  SAME ("force-chat-markers"),
+  SAME ("force-receipts"),
   SAME (NULL)
 };
 #undef SAME

--- a/tests/test-parse-message.c
+++ b/tests/test-parse-message.c
@@ -20,6 +20,7 @@ test1 (void)
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
   TpDeliveryStatus delivery_status;
+  const gchar *delivery_token;
   const gchar *id;
   const gchar *body;
   gint state;
@@ -31,7 +32,7 @@ test1 (void)
         NULL);
   ret = gabble_message_util_parse_incoming_message (
       msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status, &sent);
+      &delivery_status, &delivery_token, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "foo@bar.com");
@@ -59,6 +60,7 @@ test2 (void)
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
   TpDeliveryStatus delivery_status;
+  const gchar *delivery_token;
   const gchar *id;
   const gchar *body;
   gint state;
@@ -71,7 +73,7 @@ test2 (void)
         NULL);
   ret = gabble_message_util_parse_incoming_message (
       msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status, &sent);
+      &delivery_status, &delivery_token, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "foo@bar.com");
@@ -99,6 +101,7 @@ test3 (void)
   TpDeliveryStatus delivery_status;
   const gchar *id;
   const gchar *body;
+  const gchar *delivery_token;
   gint state;
   gboolean sent;
 
@@ -109,7 +112,7 @@ test3 (void)
         NULL);
   ret = gabble_message_util_parse_incoming_message (
       msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status, &sent);
+      &delivery_status, &delivery_token, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "foo@bar.com");
@@ -137,6 +140,7 @@ test_error (void)
   TpDeliveryStatus delivery_status;
   const gchar *id;
   const gchar *body;
+  const gchar *delivery_token;
   gint state;
   gboolean sent;
 
@@ -148,7 +152,7 @@ test_error (void)
       NULL);
   ret = gabble_message_util_parse_incoming_message (
       msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status, &sent);
+      &delivery_status, &delivery_token, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "foo@bar.com");
@@ -176,6 +180,7 @@ test_another_error (void)
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
   TpDeliveryStatus delivery_status;
+  const gchar *delivery_token;
   const gchar *id;
   const gchar *body;
   gint state;
@@ -197,7 +202,7 @@ test_another_error (void)
       NULL);
   ret = gabble_message_util_parse_incoming_message (
       msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status, &sent);
+      &delivery_status, &delivery_token, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "romeo@montague.net/garden");
@@ -226,6 +231,7 @@ test_yet_another_error (void)
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
   TpDeliveryStatus delivery_status;
+  const gchar *delivery_token;
   const gchar *id;
   const gchar *body;
   gint state;
@@ -249,7 +255,7 @@ test_yet_another_error (void)
       NULL);
   ret = gabble_message_util_parse_incoming_message (
       msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status, &sent);
+      &delivery_status, &delivery_token, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "other@starfleet.us/Enterprise");
@@ -277,6 +283,7 @@ test_google_offline (void)
   TpDeliveryStatus delivery_status;
   const gchar *id;
   const gchar *body;
+  const gchar *delivery_token;
   gint state;
   gboolean sent;
 
@@ -295,7 +302,7 @@ test_google_offline (void)
       NULL);
   ret = gabble_message_util_parse_incoming_message (
       msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status, &sent);
+      &delivery_status, &delivery_token, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "foo@bar.com");

--- a/tests/test-parse-message.c
+++ b/tests/test-parse-message.c
@@ -15,6 +15,7 @@ test1 (void)
   WockyStanza *msg;
   gboolean ret;
   const gchar *from;
+  const gchar *to;
   time_t stamp;
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
@@ -22,22 +23,25 @@ test1 (void)
   const gchar *id;
   const gchar *body;
   gint state;
+  gboolean sent;
 
   msg = wocky_stanza_build (WOCKY_STANZA_TYPE_MESSAGE, WOCKY_STANZA_SUB_TYPE_NONE,
         "foo@bar.com", NULL,
         '@', "id", "a867c060-bd3f-4ecc-a38f-3e306af48e4c",
         NULL);
   ret = gabble_message_util_parse_incoming_message (
-      msg, &from, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status);
+      msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
+      &delivery_status, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "foo@bar.com");
+  g_assert_null (to);
   g_assert_cmpuint (stamp, ==, 0);
   g_assert_cmpuint (type, ==, TP_CHANNEL_TEXT_MESSAGE_TYPE_NOTICE);
   g_assert_cmpstr (body, ==, NULL);
   g_assert_cmpuint (state, ==, -1);
   g_assert_cmpuint (send_error, ==, GABBLE_TEXT_CHANNEL_SEND_NO_ERROR);
+  g_assert_false (sent);
   g_object_unref (msg);
 }
 
@@ -50,6 +54,7 @@ test2 (void)
   WockyStanza *msg;
   gboolean ret;
   const gchar *from;
+  const gchar *to;
   time_t stamp;
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
@@ -57,6 +62,7 @@ test2 (void)
   const gchar *id;
   const gchar *body;
   gint state;
+  gboolean sent;
 
   msg = wocky_stanza_build (WOCKY_STANZA_TYPE_MESSAGE, WOCKY_STANZA_SUB_TYPE_NONE,
         "foo@bar.com", NULL,
@@ -64,16 +70,18 @@ test2 (void)
         '(', "body", '$', "hello", ')',
         NULL);
   ret = gabble_message_util_parse_incoming_message (
-      msg, &from, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status);
+      msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
+      &delivery_status, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "foo@bar.com");
+  g_assert_null (to);
   g_assert_cmpuint (stamp, ==, 0);
   g_assert_cmpuint (type, ==, TP_CHANNEL_TEXT_MESSAGE_TYPE_NOTICE);
   g_assert_cmpstr (body, ==, "hello");
   g_assert_cmpuint (state, ==, -1);
   g_assert_cmpuint (send_error, ==, GABBLE_TEXT_CHANNEL_SEND_NO_ERROR);
+  g_assert_false (sent);
   g_object_unref (msg);
 }
 
@@ -84,6 +92,7 @@ test3 (void)
   WockyStanza *msg;
   gboolean ret;
   const gchar *from;
+  const gchar *to;
   time_t stamp;
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
@@ -91,6 +100,7 @@ test3 (void)
   const gchar *id;
   const gchar *body;
   gint state;
+  gboolean sent;
 
   msg = wocky_stanza_build (WOCKY_STANZA_TYPE_MESSAGE, WOCKY_STANZA_SUB_TYPE_CHAT,
         "foo@bar.com", NULL,
@@ -98,16 +108,18 @@ test3 (void)
         '(', "body", '$', "hello", ')',
         NULL);
   ret = gabble_message_util_parse_incoming_message (
-      msg, &from, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status);
+      msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
+      &delivery_status, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "foo@bar.com");
+  g_assert_null (to);
   g_assert_cmpuint (stamp, ==, 0);
   g_assert_cmpuint (type, ==, TP_CHANNEL_TEXT_MESSAGE_TYPE_NORMAL);
   g_assert_cmpstr (body, ==, "hello");
   g_assert_cmpuint (state, ==, -1);
   g_assert_cmpuint (send_error, ==, GABBLE_TEXT_CHANNEL_SEND_NO_ERROR);
+  g_assert_false (sent);
   g_object_unref (msg);
 }
 
@@ -118,6 +130,7 @@ test_error (void)
   WockyStanza *msg;
   gboolean ret;
   const gchar *from;
+  const gchar *to;
   time_t stamp;
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
@@ -125,6 +138,7 @@ test_error (void)
   const gchar *id;
   const gchar *body;
   gint state;
+  gboolean sent;
 
   msg = wocky_stanza_build (
       WOCKY_STANZA_TYPE_MESSAGE, WOCKY_STANZA_SUB_TYPE_ERROR,
@@ -133,17 +147,19 @@ test_error (void)
       '(', "error", '$', "oops", ')',
       NULL);
   ret = gabble_message_util_parse_incoming_message (
-      msg, &from, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status);
+      msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
+      &delivery_status, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "foo@bar.com");
+  g_assert_null (to);
   g_assert_cmpuint (stamp, ==, 0);
   g_assert_cmpuint (type, ==, TP_CHANNEL_TEXT_MESSAGE_TYPE_NOTICE);
   g_assert_cmpstr (body, ==, NULL);
   g_assert_cmpuint (state, ==, -1);
   g_assert_cmpuint (send_error, ==, TP_CHANNEL_TEXT_SEND_ERROR_UNKNOWN);
   g_assert_cmpuint (delivery_status, ==, TP_DELIVERY_STATUS_PERMANENTLY_FAILED);
+  g_assert_false (sent);
   g_object_unref (msg);
 }
 
@@ -155,6 +171,7 @@ test_another_error (void)
   WockyStanza *msg;
   gboolean ret;
   const gchar *from;
+  const gchar *to;
   time_t stamp;
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
@@ -162,6 +179,7 @@ test_another_error (void)
   const gchar *id;
   const gchar *body;
   gint state;
+  gboolean sent;
   const gchar *message = "Wherefore art thou, Romeo?";
 
   msg = wocky_stanza_build (
@@ -178,17 +196,19 @@ test_another_error (void)
       ')',
       NULL);
   ret = gabble_message_util_parse_incoming_message (
-      msg, &from, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status);
+      msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
+      &delivery_status, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "romeo@montague.net/garden");
+  g_assert_cmpstr (to, ==, "juliet@capulet.com/balcony");
   g_assert_cmpuint (stamp, ==, 0);
   g_assert_cmpuint (type, ==, TP_CHANNEL_TEXT_MESSAGE_TYPE_NOTICE);
   g_assert_cmpstr (body, ==, message);
   g_assert_cmpuint (state, ==, -1);
   g_assert_cmpuint (send_error, ==, TP_CHANNEL_TEXT_SEND_ERROR_INVALID_CONTACT);
   g_assert_cmpuint (delivery_status, ==, TP_DELIVERY_STATUS_PERMANENTLY_FAILED);
+  g_assert_false (sent);
   g_object_unref (msg);
 }
 
@@ -201,6 +221,7 @@ test_yet_another_error (void)
   WockyStanza *msg;
   gboolean ret;
   const gchar *from;
+  const gchar *to;
   time_t stamp;
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
@@ -208,6 +229,7 @@ test_yet_another_error (void)
   const gchar *id;
   const gchar *body;
   gint state;
+  gboolean sent;
   const gchar *message = "Its trilling seems to have a tranquilizing effect on "
                          "the human nervous system.";
 
@@ -226,17 +248,19 @@ test_yet_another_error (void)
       ')',
       NULL);
   ret = gabble_message_util_parse_incoming_message (
-      msg, &from, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status);
+      msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
+      &delivery_status, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "other@starfleet.us/Enterprise");
+  g_assert_cmpstr (to, ==, "spock@starfleet.us/Enterprise");
   g_assert_cmpuint (stamp, ==, 0);
   g_assert_cmpuint (type, ==, TP_CHANNEL_TEXT_MESSAGE_TYPE_NOTICE);
   g_assert_cmpstr (body, ==, message);
   g_assert_cmpuint (state, ==, -1);
   g_assert_cmpuint (send_error, ==, TP_CHANNEL_TEXT_SEND_ERROR_OFFLINE);
   g_assert_cmpuint (delivery_status, ==, TP_DELIVERY_STATUS_TEMPORARILY_FAILED);
+  g_assert_false (sent);
   g_object_unref (msg);
 }
 
@@ -246,6 +270,7 @@ test_google_offline (void)
   WockyStanza *msg;
   gboolean ret;
   const gchar *from;
+  const gchar *to;
   time_t stamp;
   TpChannelTextMessageType type;
   TpChannelTextSendError send_error;
@@ -253,6 +278,7 @@ test_google_offline (void)
   const gchar *id;
   const gchar *body;
   gint state;
+  gboolean sent;
 
   msg = wocky_stanza_build (WOCKY_STANZA_TYPE_MESSAGE, WOCKY_STANZA_SUB_TYPE_NONE,
       "foo@bar.com", NULL,
@@ -268,16 +294,18 @@ test_google_offline (void)
       ')',
       NULL);
   ret = gabble_message_util_parse_incoming_message (
-      msg, &from, &stamp, &type, &id, &body, &state, &send_error,
-      &delivery_status);
+      msg, &from, &to, &stamp, &type, &id, &body, &state, &send_error,
+      &delivery_status, &sent);
   g_assert (ret);
   g_assert_cmpstr (id, ==, "a867c060-bd3f-4ecc-a38f-3e306af48e4c");
   g_assert_cmpstr (from, ==, "foo@bar.com");
+  g_assert_null (to);
   g_assert_cmpuint (stamp, ==, 1190899454);
   g_assert_cmpuint (type, ==, TP_CHANNEL_TEXT_MESSAGE_TYPE_NORMAL);
   g_assert_cmpstr (body, ==, "hello");
   g_assert_cmpuint (state, ==, -1);
   g_assert_cmpuint (send_error, ==, GABBLE_TEXT_CHANNEL_SEND_NO_ERROR);
+  g_assert_false (sent);
   g_object_unref (msg);
 }
 


### PR DESCRIPTION
Implementations of Message Carbons and Chat Markers. 
Chat markers [read] feature is based on the pending messages feature of Telepathy which should ack messages when its displayed to the user. Not all clients handle it this way, though.

Message Carbons support based on a patch by Michael Kuhn.
  
Bug regarding XEP-0280: https://github.com/TelepathyIM/telepathy-gabble/issues/2