### PR TITLE
XEP-0084: User Avatar (fetching only)

### DIFF
--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -54,6 +54,8 @@ static const Feature self_advertised_features[] =
 #endif
 
   { FEATURE_FIXED, NS_DISCO_INFO },
+  { FEATURE_FIXED, NS_AVATAR_METADATA },
+  { FEATURE_FIXED, NS_AVATAR_METADATA "+notify" },
   { FEATURE_FIXED, NS_CHAT_STATES },
   { FEATURE_FIXED, NS_NICK },
   { FEATURE_FIXED, NS_NICK "+notify" },

--- a/src/conn-avatars.c
+++ b/src/conn-avatars.c
@@ -1039,7 +1039,7 @@ pep_avatar_request_data_cb (
   g_array_unref (arr);
   g_free (bindata);
 
-  DEBUG ("retreived avatar from %d with size=%ld, sha1='%s'", handle, outlen, sha1);
+  DEBUG ("retrieved avatar from %d with size=%zd, sha1='%s'", handle, outlen, sha1);
 
   // is this really needed?
   if (sha1)

--- a/src/conn-avatars.c
+++ b/src/conn-avatars.c
@@ -720,7 +720,7 @@ gabble_connection_request_avatars (TpSvcConnectionInterfaceAvatars *iface,
                 GUINT_TO_POINTER (contact)))
             {
               gchar *id;
-              if (id = g_hash_table_lookup (self->pep_avatar_hashes, GINT_TO_POINTER(contact)))
+              if ((id = g_hash_table_lookup (self->pep_avatar_hashes, GINT_TO_POINTER(contact))))
                 {
                   pep_request_ctx *ctx = pep_avatar_request_data (self, contact, id);
                   g_hash_table_insert (self->avatar_requests,
@@ -934,7 +934,7 @@ conn_avatars_fill_contact_attributes (GObject *obj,
 
           if (NULL != presence->avatar_sha1)
             g_value_set_string (val, presence->avatar_sha1);
-          else if (id = g_hash_table_lookup (self->pep_avatar_hashes, GINT_TO_POINTER(handle)))
+          else if ((id = g_hash_table_lookup (self->pep_avatar_hashes, GINT_TO_POINTER(handle))))
             g_value_set_string (val, id);
           else
             g_value_set_string (val, "");
@@ -1098,13 +1098,12 @@ pep_avatar_metadata_node_changed (WockyPepService *pep,
       return;
     }
 
-  gchar *type;
   info = NULL;
   wocky_node_iter_init (&iter, metadata, "info", NULL);
   while (wocky_node_iter_next (&iter, &info))
     {
-      gchar *url = wocky_node_get_attribute (info, "url");
-      type = wocky_node_get_attribute (info, "type");
+      const gchar *url = wocky_node_get_attribute (info, "url");
+      const gchar *type = wocky_node_get_attribute (info, "type");
       //Found one of type png which is not an url node
       if ((type) && (g_strcmp0(type, "image/png") == 0) && (!url))
         {

--- a/src/conn-avatars.c
+++ b/src/conn-avatars.c
@@ -1182,7 +1182,7 @@ conn_avatars_init (GabbleConnection *conn)
           conn_avatars_fill_contact_attributes);
 
   conn->pep_avatar = wocky_pep_service_new (NS_AVATAR_METADATA, TRUE);
-  conn->pep_avatar_hashes = g_hash_table_new (g_direct_hash, g_direct_equal);
+  conn->pep_avatar_hashes = g_hash_table_new_full (g_direct_hash, g_direct_equal, NULL, g_free);
 
   g_signal_connect (conn->pep_avatar, "changed",
       G_CALLBACK (pep_avatar_metadata_node_changed), conn);

--- a/src/connection.c
+++ b/src/connection.c
@@ -1387,6 +1387,7 @@ gabble_connection_dispose (GObject *object)
   tp_clear_object (&self->pep_olpc_current_act);
   tp_clear_object (&self->pep_olpc_act_props);
   tp_clear_object (&self->pep_avatar);
+  tp_clear_object (&self->pep_avatar_hashes);
 
   conn_sidecars_dispose (self);
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -1386,6 +1386,7 @@ gabble_connection_dispose (GObject *object)
   tp_clear_object (&self->pep_olpc_activities);
   tp_clear_object (&self->pep_olpc_current_act);
   tp_clear_object (&self->pep_olpc_act_props);
+  tp_clear_object (&self->pep_avatar);
 
   conn_sidecars_dispose (self);
 
@@ -2036,6 +2037,7 @@ connector_connected (GabbleConnection *self,
   wocky_pep_service_start (self->pep_olpc_activities, self->session);
   wocky_pep_service_start (self->pep_olpc_current_act, self->session);
   wocky_pep_service_start (self->pep_olpc_act_props, self->session);
+  wocky_pep_service_start (self->pep_avatar, self->session);
 
   /* Don't use wocky_session_start as we don't want to start all the
    * components (Roster, presence-manager, etc) for now */

--- a/src/connection.h
+++ b/src/connection.h
@@ -240,6 +240,10 @@ struct _GabbleConnection {
     WockyPepService *pep_olpc_activities;
     WockyPepService *pep_olpc_current_act;
     WockyPepService *pep_olpc_act_props;
+    WockyPepService *pep_avatar;
+
+    /* list to recognize pep avatars */
+    GHashTable *pep_avatar_hashes;
 
     /* Sidecars */
     /* gchar *interface → GabbleSidecar */

--- a/src/namespaces.h
+++ b/src/namespaces.h
@@ -28,6 +28,8 @@
 #define NS_SM2                  "urn:xmpp:sm:2"
 #define NS_SM3                  "urn:xmpp:sm:3"
 #define NS_AMP                  "http://jabber.org/protocol/amp"
+#define NS_AVATAR_DATA          "urn:xmpp:avatar:data"
+#define NS_AVATAR_METADATA      "urn:xmpp:avatar:metadata"
 #define NS_BYTESTREAMS          "http://jabber.org/protocol/bytestreams"
 #define NS_CHAT_STATES          "http://jabber.org/protocol/chatstates"
 #define NS_CHAT_MARKERS         "urn:xmpp:chat-markers:0"


### PR DESCRIPTION
The User Avatar patch enables fetching of PEP based avatars. This is used by the Conversations Android client. Unfortunately, Conversations tends to use webp images, which are not supported by some systems or clients per default.

(still missing mime type detection)