### PR TITLE
Support XEP-0203: Delayed Delivery

### DIFF
--- a/src/message-util.c
+++ b/src/message-util.c
@@ -433,6 +433,27 @@ gabble_message_util_parse_incoming_message (WockyStanza *message,
         }
     }
 
+  node = wocky_node_get_child_ns (message_node, "delay", NS_XMPP_DELAY);
+  if (node != NULL)
+    {
+      const gchar *stamp_str;
+      stamp_str = wocky_node_get_attribute (node, "stamp");
+
+      if (stamp_str != NULL)
+        {
+          GTimeVal timeval = { 0, 0 };
+          if (g_time_val_from_iso8601 (stamp_str, &timeval))
+            {
+              *stamp = timeval.tv_sec;
+            }
+          else
+            {
+              DEBUG ("%s: malformed date string '%s' for urn:xmpp:delay",
+                  G_STRFUNC, stamp_str);
+            }
+        }
+    }
+
   /*
    * Parse body if it exists.
    */

--- a/src/namespaces.h
+++ b/src/namespaces.h
@@ -115,6 +115,7 @@
 #define NS_VCARD_TEMP_UPDATE    "vcard-temp:x:update"
 #define NS_X_DATA               "jabber:x:data"
 #define NS_X_DELAY              "jabber:x:delay"
+#define NS_XMPP_DELAY           "urn:xmpp:delay"
 #define NS_X_CONFERENCE         "jabber:x:conference"
 #define NS_XMPP_STANZAS         "urn:ietf:params:xml:ns:xmpp-stanzas"
 #define NS_VERSION              "jabber:iq:version"


### PR DESCRIPTION
from [XEP-0203](https://xmpp.org/extensions/xep-0203.html):

"Although the XMPP protocol extension defined in Legacy Delayed Delivery (XEP-0091) provides a way to communicate that an XML stanza (typically a <message/> or <presence/> stanza) has been delivered with a delay, the timestamp format defined in that document does not adhere to the recommended date and time profiles for XMPP protocols defined in XMPP Date and Time Profiles (XEP-0082). Therefore, this document defines a replacement for XEP-0091 which enables communication of delayed delivery information while adhering to XEP-0082."

XEP-0203 has been declared a final xmpp standard in 2009.