### PR TITLE
XEP-0198 SM support

### DIFF
--- a/src/search-manager.c
+++ b/src/search-manager.c
@@ -167,6 +167,9 @@ connection_status_changed_cb (GabbleConnection *conn,
   switch (status)
     {
       case TP_CONNECTION_STATUS_CONNECTING:
+        /* FIXME: I don't think this status is actually used in gabble */
+        if (reason == TP_CONNECTION_STATUS_REASON_NETWORK_ERROR)
+          return;
         /* Track Search server available on the connection.
          *
          * The GabbleDisco object is created after the channel manager so we


### PR DESCRIPTION
Add support for wocky Stream Management into gabble connection.
Wocky can do SM alone by storing connector and its channel managers for future reconnections, however since resumption may not-fatally fail (while still allowing to continue with new connection) it requires separate handling within Gabble.

This PR implements minimal support, which however does not require any changes in the underlying Glib or DBus APIs. When wocky signals about connection resumption GabbleConnection lets it to continue and merely signal up the CONNECTING state. This allows Client to update the UI to indicate limited connectivity state. In addition signal handler increases IQ Timeouts (VCard and Disco for now) to 30min. When resumed is signaled it merely forwards it upstream as CONNECTED state. And finally when resume-done is signaled (which indicates queue flush) it resets IQ timeouts back to normal values.

closes #16 