### PR TITLE
Multiple Regression fixes

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -1387,7 +1387,7 @@ gabble_connection_dispose (GObject *object)
   tp_clear_object (&self->pep_olpc_current_act);
   tp_clear_object (&self->pep_olpc_act_props);
   tp_clear_object (&self->pep_avatar);
-  tp_clear_object (&self->pep_avatar_hashes);
+  g_clear_pointer (&self->pep_avatar_hashes, g_hash_table_unref);
 
   conn_sidecars_dispose (self);
 

--- a/src/im-factory.c
+++ b/src/im-factory.c
@@ -213,7 +213,7 @@ im_factory_message_cb (
   gint state;
   TpChannelTextSendError send_error;
   TpDeliveryStatus delivery_status;
-  const gchar *delivery_token;
+  const gchar *delivery_token = NULL;
   gboolean create_if_missing;
   gboolean sent;
 

--- a/src/server-tls-manager.c
+++ b/src/server-tls-manager.c
@@ -164,7 +164,8 @@ complete_verify (GabbleServerTLSManager *self)
           g_object_ref (self->priv->channel));
     }
 
-  g_simple_async_result_complete (self->priv->async_result);
+  if (self->priv->async_result != NULL)
+    g_simple_async_result_complete (self->priv->async_result);
 
   /* Reset to initial state */
   tp_clear_pointer (&self->priv->peername, g_free);
@@ -343,6 +344,11 @@ gabble_server_tls_manager_verify_async (WockyTLSHandler *handler,
   GSimpleAsyncResult *result;
 #if defined(WOCKY_API_VERSION) && WOCKY_API_VERSION >= WOCKY_API_VER_0_1
   const gchar *peername = NULL;
+  GSocketConnectable *identity;
+
+  identity = g_tls_client_connection_get_server_identity (G_TLS_CLIENT_CONNECTION (tls_session));
+  if (G_IS_NETWORK_ADDRESS (identity))
+    peername = g_network_address_get_hostname (G_NETWORK_ADDRESS (identity));
 #endif
 
   g_return_if_fail (self->priv->async_result == NULL);


### PR DESCRIPTION
Latest changes introduced several regressions where under certain conditions the service crashes (segfault) on connection closure.

This MR fixes those identified regressions.

Closes #19 