### PR TITLE
Several small fixes

### DIFF
--- a/src/connection-manager.c
+++ b/src/connection-manager.c
@@ -37,6 +37,7 @@
 #include "extensions/extensions.h"
 
 #include "protocol.h"
+#include "roster-cache.h"
 
 G_DEFINE_TYPE(GabbleConnectionManager,
     gabble_connection_manager,
@@ -70,6 +71,7 @@ static void
 gabble_connection_manager_finalize (GObject *object)
 {
   wocky_caps_cache_free_shared ();
+  roster_cache_free_shared ();
   gabble_debug_free ();
 
   G_OBJECT_CLASS (gabble_connection_manager_parent_class)->finalize (object);

--- a/src/roster-cache.c
+++ b/src/roster-cache.c
@@ -604,7 +604,10 @@ roster_cache_get_roster (RosterCache *self,
 
   if (!roster_cache_select (self, &stmt,
         "SELECT jid,name,subscription FROM roster WHERE user=?", user, NULL))
-    return NULL;
+    {
+      wocky_node_free (roster);
+      return NULL;
+    }
 
   do
     {
@@ -618,7 +621,7 @@ roster_cache_get_roster (RosterCache *self,
         '@', "jid", val,
         '@', "name", ((name != NULL)? name : (guchar *)""),
         '@', "subscription",
-          ((sub & 3)?((sub & 1)?(sub & 2 ? "both":"to"):"from"):"none"),
+          ((sub & 3)?((sub & 1)?(sub & 2 ? "both":"from"):"to"):"none"),
         '*', &item,
         ')', NULL);
       if (sub & 8)

--- a/src/roster-cache.c
+++ b/src/roster-cache.c
@@ -725,7 +725,7 @@ roster_cache_update_roster (RosterCache *self,
           while (wocky_node_iter_next (&jter, &group))
             {
               if (!roster_cache_insert (self,
-                  "INSERT INTO groups(user, jid, group) VALUES(?, ?, ?)",
+                  "INSERT INTO groups(user, jid, grp) VALUES(?, ?, ?)",
                   user, jid, group->content, NULL, NULL))
                 goto err;
             }

--- a/src/roster.c
+++ b/src/roster.c
@@ -1446,8 +1446,10 @@ got_roster_iq (GabbleRoster *roster,
 
   if (query_node)
     {
+      const gchar *ver = wocky_node_get_attribute (query_node, "ver");
       process_roster (roster, query_node);
-      if (roster->priv->rcache != NULL)
+
+      if (roster->priv->rcache != NULL && ver != NULL && strlen (ver) != 0)
         {
           const gchar *user = conn_util_get_bare_self_jid (priv->conn);
           DEBUG ("updating roster cache for %s", user);

--- a/src/roster.c
+++ b/src/roster.c
@@ -229,11 +229,7 @@ gabble_roster_finalize (GObject *object)
   if (priv->version != NULL)
     g_string_free (priv->version, TRUE);
 
-  if (priv->rcache != NULL)
-    {
-      roster_cache_free_shared ();
-      priv->rcache = NULL;
-    }
+  g_clear_object (&priv->rcache);
 
   G_OBJECT_CLASS (gabble_roster_parent_class)->finalize (object);
 }

--- a/src/vcard-manager.c
+++ b/src/vcard-manager.c
@@ -672,10 +672,11 @@ status_changed_cb (GObject *object,
     {
       gchar *alias;
       GabbleConnectionAliasSource alias_src;
+      TpHandle handle = tp_base_connection_get_self_handle (base);
+      GabbleVCardCacheEntry *entry = cache_entry_get (self, handle);
 
       /* if we have a better alias, patch it into our vCard on the server */
-      alias_src = _gabble_connection_get_cached_alias (conn,
-          tp_base_connection_get_self_handle (base), &alias);
+      alias_src = _gabble_connection_get_cached_alias (conn, handle, &alias);
 
       if (alias_src >= GABBLE_CONNECTION_ALIAS_FROM_VCARD)
         {
@@ -686,10 +687,12 @@ status_changed_cb (GObject *object,
 
       g_free (alias);
 
+      if (entry && entry->vcard_node)
+        return;
+
       /* FIXME: we happen to know that synchronous errors can't happen */
-      gabble_vcard_manager_request (self,
-          tp_base_connection_get_self_handle (base), 0,
-          initial_request_cb, NULL, (GObject *) self);
+      gabble_vcard_manager_request (self, handle, 0, initial_request_cb, NULL,
+          (GObject *) self);
     }
 }
 

--- a/tests/twisted/meson.build
+++ b/tests/twisted/meson.build
@@ -117,6 +117,8 @@ if has_twisted.returncode() == 0 and has_pydbus.returncode() == 0
     test('@0@'.format(t),
         python,
 	args: [t],
+        # Explicit dependency on gabble binary and all plugins, including test_lib
+        depends: [ tp_gabble_debug, plugins, test_lib ],
         env: [
           'PYTHONPATH=@0@:@1@:@0@/jingle'.format(meson.current_source_dir(),meson.current_build_dir()),
           'CHECK_TWISTED_PORT=@0@'.format(6666 + tnum),


### PR DESCRIPTION
While developing tests for new functionality these bugs were discovered:
* Wrong subscription direction is cached (from/to) in roster-cache
* Wrong SQL syntax (wrong column name) for roster-cache group
* Roster-cache is meant to be global singleton but is actually destroyed by connection destructor
* Skip cache processing for versionless roster-pushes (they trigger WARN which aborts the test)
* During quick successive re-connection (eg sm resume) vcard is still cached so request fails assertion
* Put gabble libs and binary as explicit dependency for the test, so that it build it before testing (fails on fedora otherwise)